### PR TITLE
Mixed changes to improve numerics and tagging

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -18,7 +18,6 @@ train: true
 evaluate: true
 evaluation:
  batchsize: 1024
-save_every_n_steps: null
 
 plot: true
 plotting:

--- a/config/training/amp_default.yaml
+++ b/config/training/amp_default.yaml
@@ -24,7 +24,6 @@ es_load_best_model: true
 log_every_n_steps: 1000
 validate_every_n_steps: 1000
 validate_every_n_epochs_min: null
-checkpoint_every_n_steps: null
 
 log_grad_norm: true
 clip_grad_norm_lframesnet: null

--- a/config/training/amp_gatrvals_default.yaml
+++ b/config/training/amp_gatrvals_default.yaml
@@ -20,7 +20,6 @@ es_load_best_model: true
 
 log_every_n_steps: 1000
 validate_every_n_steps: 1252
-checkpoint_every_n_steps: null
 
 log_grad_norm: true
 clip_grad_norm: 1000

--- a/config/training/eg_default.yaml
+++ b/config/training/eg_default.yaml
@@ -24,7 +24,6 @@ es_load_best_model: true
 log_every_n_steps: 1000
 validate_every_n_steps: 1000
 validate_every_n_epochs_min: null
-checkpoint_every_n_steps: null
 
 log_grad_norm: true
 clip_grad_norm_lframesnet: null

--- a/config/training/tag_default.yaml
+++ b/config/training/tag_default.yaml
@@ -26,7 +26,6 @@ es_load_best_model: true
 log_every_n_steps: 200
 validate_every_n_steps: 5000
 validate_every_n_epochs_min: null
-checkpoint_every_n_steps: null
 
 log_grad_norm: true
 clip_grad_norm_lframesnet: null

--- a/config_quick/training/default.yaml
+++ b/config_quick/training/default.yaml
@@ -23,7 +23,6 @@ es_load_best_model: true
 log_every_n_steps: 200
 validate_every_n_steps: 5000
 validate_every_n_epochs_min: null
-checkpoint_every_n_steps: null
 
 log_grad_norm: true
 clip_grad_norm_lframesnet: null

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -505,17 +505,6 @@ class BaseExperiment:
             t0 = time.time()
             self._step(data, step)
             train_time += time.time() - t0
-            if self.cfg.training.checkpoint_every_n_steps is not None:
-                if (step + 1) % self.cfg.training.checkpoint_every_n_steps == 0:
-                    # save model every 100k iterations without evaluating as checkpoints
-                    self._save_model(f"model_run{self.cfg.run_idx}_it{step}.pt")
-                    dt = time.time() - self.training_start_time
-                    dt_estimate = dt * self.cfg.training.iterations / (step + 1)
-                    LOGGER.info(
-                        f"Finished iteration {step+1} after {dt:.2f}s, "
-                        f"training time estimate: {dt_estimate/60:.2f}min "
-                        f"= {dt_estimate/60**2:.2f}h"
-                    )
             # validation (and early stopping)
             if (step + 1) % self.cfg.training.validate_every_n_steps == 0:
                 t0 = time.time()


### PR DESCRIPTION
### Goals
- Improve tagging numerics

### Changes
- Cleaned up tagging model initialization (was not well done in the cleanup PR)
- Preliminary solution to backward nans with `safe_softmax` (in `equigraph.py`) and `error_if_nonfinite=False` (in `base_experiment.py`)
  - Default `torch_geometric` `softmax` and `safe_softmax` without clamping both cause 'DivBackward0 returns nan'; the clamping fixes this
  - Also with clamping one sometimes gets 'IndexBackward0 returns nan' (also in the softmax); I didn't find a solution for that yet; this error happens more often for large clamping (eg -5, -2) and for small clamping(eg -20, -50) and for -10 it seems to be most stable - I don't understand why
  - The problem happens more often with larger LR and when using the Lion optimizer. I debugged with lr=1e-2 on JetClass (there the problem appears consistently after ~100 iterations), with lr=1e-3 it almost always gets up to 1000 iterations (I didn't train longer)