### PR TITLE
Pull more changes from tagger quantization

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,6 +3,7 @@ exp_type: ???
 run_name: null
 base_dir: .
 
+gpus: -1
 jobid: null
 seed: null
 debug: false

--- a/config_quick/default.yaml
+++ b/config_quick/default.yaml
@@ -3,6 +3,7 @@ exp_type: ???
 run_name: null
 base_dir: .
 
+gpus: -1
 jobid: null
 seed: null
 debug: false
@@ -10,7 +11,7 @@ use_float64: false
 float32_matmul_precision: highest
 
 warm_start_idx: null
-save: true
+save: false
 use_mlflow: false
 save_source: true
 ema: false

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -17,7 +17,7 @@ from torch_ema import ExponentialMovingAverage
 
 import experiments.logger
 from experiments.logger import FORMATTER, LOGGER, MEMORY_HANDLER, RankFilter
-from experiments.misc import flatten_dict, get_device
+from experiments.misc import flatten_dict
 from experiments.mlflow import log_mlflow
 from experiments.ranger import Ranger
 
@@ -314,7 +314,11 @@ class BaseExperiment:
         LOGGER.debug("Logger initialized")
 
     def _init_backend(self):
-        self.device = get_device()
+        self.device = (
+            torch.device("cuda")
+            if torch.cuda.is_available() and self.cfg.gpus != 0
+            else torch.device("cpu")
+        )
         LOGGER.info(f"Using device {self.device}; see {self.world_size} GPUs in total")
         self.dtype = torch.float64 if self.cfg.use_float64 else torch.float32
         if torch.cuda.is_available() and torch.cuda.is_bf16_supported():

--- a/experiments/base_plots.py
+++ b/experiments/base_plots.py
@@ -27,6 +27,7 @@ def plot_loss(file, losses, lr=None, labels=None, logy=True):
         axright = ax.twinx()
         axright.plot(iterations, lr, label="learning rate", color="crimson")
         axright.set_ylabel("Learning rate", fontsize=FONTSIZE)
+
     ax.set_xlabel("Number of iterations", fontsize=FONTSIZE)
     ax.set_ylabel("Loss", fontsize=FONTSIZE)
     ax.legend(fontsize=FONTSIZE_LEGEND, frameon=False, loc="upper right")

--- a/experiments/misc.py
+++ b/experiments/misc.py
@@ -12,11 +12,6 @@ except ModuleNotFoundError:
     pass
 
 
-def get_device() -> torch.device:
-    """Gets CUDA if available, CPU else."""
-    return torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-
-
 def flatten_dict(d, parent_key="", sep="."):
     """Flattens a nested dictionary with str keys."""
     items = []

--- a/experiments/tagging/embedding.py
+++ b/experiments/tagging/embedding.py
@@ -112,11 +112,15 @@ def embed_tagging_data(fourmomenta, scalars, ptr, cfg_data):
 
     if cfg_data.boost_jet:
         # boost to the jet rest frame to avoid large boosts
-        jet = scatter(fourmomenta, batch, dim=0, reduce="sum").index_select(0, batch)
+        jet = scatter(
+            fourmomenta[~is_spurion], batch[~is_spurion], dim=0, reduce="sum"
+        ).index_select(0, batch)
         jet_boost = restframe_boost(jet)
         fourmomenta = torch.einsum("ijk,ik->ij", jet_boost, fourmomenta)
 
-    jet = scatter(fourmomenta, batch, dim=0, reduce="sum").index_select(0, batch)
+    jet = scatter(fourmomenta[~is_spurion], batch[~is_spurion], dim=0, reduce="sum").index_select(
+        0, batch
+    )
     tagging_features = get_tagging_features(
         fourmomenta,
         jet,

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -49,6 +49,9 @@ class TaggingExperiment(BaseExperiment):
             elif modelname == "CGENN":
                 # CGENN cant handle zero scalar inputs -> give 1 input with zeros
                 self.cfg.model.net.in_features_h = 1 + in_s_channels
+
+            # doesn't affect results and never needed
+            self.cfg.data.boost_jet = False
         elif modelname in [
             "Transformer",
             "ParticleTransformer",
@@ -75,6 +78,9 @@ class TaggingExperiment(BaseExperiment):
                 )
                 self.cfg.model.framesnet.equivectors.num_scalars = self.extra_scalars
                 self.cfg.model.framesnet.equivectors.num_scalars += num_tagging_features
+            else:
+                # not allowed, because the network is not Lorentz-equivariant
+                self.cfg.data.boost_jet = False
         else:
             raise NotImplementedError(f"Model {modelname} not implemented")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pre-commit>=3.7
 mlflow-skinny # can optionally install extras, see https://pypi.org/project/mlflow-skinny/
 
 # standard science stack
-numpy
+numpy>=1.19.5,<2.0.0 # constrain version for weaver
 matplotlib
 scikit-learn
 

--- a/run.py
+++ b/run.py
@@ -17,7 +17,12 @@ from experiments.tagging.toptagxlexperiment import TopTagXLExperiment
 
 @hydra.main(config_path="config_quick", config_name="toptagging", version_base=None)
 def main(cfg):
-    world_size = torch.cuda.device_count() if torch.cuda.is_available() else 1
+    if torch.cuda.is_available() and cfg.gpus == -1:
+        world_size = torch.cuda.device_count()
+    elif torch.cuda.is_available() and cfg.gpus >= 1:
+        world_size = cfg.gpus
+    else:
+        world_size = 1
 
     if world_size > 1:
         os.environ.setdefault("TORCH_NCCL_ASYNC_ERROR_HANDLING", "1")


### PR DESCRIPTION
### Changes
- Set `cfg.data.boost_jet=false` for non-equivariant and 'Lorentz-equivariance by architecture' networks (this was a bad mistake for previous top-taggers)
- Option `cfg.gpus` to be able to (a) select the CPU when GPUs are available (useful for CPU inference tests), (b) select a subset of GPUs when multiple GPUs are available (useful for 'illegal jobs')
- Update requirements: `lloca` and `lgatr` now support `flash-attn`; constrain `numpy<2` to avoid conflict with old `uproot` versions used in weaver