### PR TITLE
Correct double-indexing

### DIFF
--- a/experiments/eventgen/utils.py
+++ b/experiments/eventgen/utils.py
@@ -101,7 +101,7 @@ def ensure_onshell(fourmomenta, onshell_list, onshell_mass, mass_reg=1e-1):
 
     # ensure minimal mass
     mask = get_mass(fourmomenta) < mass_reg
-    fourmomenta[mask][..., 0] = ((fourmomenta[mask][..., 1:] ** 2).sum(dim=-1) + mass_reg**2).sqrt()
+    fourmomenta[mask, 0] = ((fourmomenta[mask, 1:] ** 2).sum(dim=-1) + mass_reg**2).sqrt()
     return fourmomenta
 
 


### PR DESCRIPTION
Annoying torch feature:
Setting `fourmomenta[mask][..., 0] = ...` does not work. 
Using advanced indexing `fourmomenta[mask]` returns a new tensor that does not share memory. You can replace values in `fourmomenta` by setting `fourmomenta[mask] = ...` but if you slice it again with `fourmomenta[mask][...] = ...` you are now modifying this new tensor and not `fourmomenta`