### PR TITLE
Correct top tagging model config

### DIFF
--- a/config/toptagging.yaml
+++ b/config/toptagging.yaml
@@ -9,5 +9,5 @@ data:
 defaults:
  - training: top_transformer
  - tagging
- - model@: tag_top_transformer
+ - override model: tag_top_transformer
  - _self_


### PR DESCRIPTION
The top tagging config currently does not use the correct model.
Setting `- model@: tag_top_transformer` will merge the `tag_top_transformer` config with the one calling it and not change the default `model: tag_transformer` loaded from the `tagging`config (which is why the model config appeared twice in the config file saved in the run folder, one as model and one as the base config attributes)
