### PR TITLE
go from .all to .any in dataset.py to preserve real particles while dropping padding

### DIFF
--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -224,15 +224,15 @@ https://arxiv.org/abs/2508.14898 Table 7
 # Architecture-level symmetry breaking
 python run.py -cp config -cn jctagging data.beam_reference=null data.add_time_reference=false # non-equivariant
 python run.py -cp config -cn jctagging data.beam_reference=null data.add_time_reference=false model/framesnet=learnedso2 # SO(2)
-python run.py -cp config -cn jctagging data.tagging_features_framesnet=zinvariant data.beam_reference=null data.add_time_reference=false model/framesnet=learnedz # SO(1,1)xSO(2)
-python run.py -cp config -cn jctagging data.tagging_features_framesnet=so3invariant data.beam_reference=null data.add_time_reference=false model/framesnet=learnedso3 # SO(3)
-python run.py -cp config -cn jctagging data.tagging_features_framesnet=null data.beam_reference=null data.add_time_reference=false model/framesnet=learnedpd # SO(1,3)
+python run.py -cp config -cn jctagging data.tagging_features=zinvariant data.beam_reference=null data.add_time_reference=false model/framesnet=learnedz # SO(1,1)xSO(2)
+python run.py -cp config -cn jctagging data.tagging_features=so3invariant data.beam_reference=null data.add_time_reference=false model/framesnet=learnedso3 # SO(3)
+python run.py -cp config -cn jctagging data.tagging_features=null data.beam_reference=null data.add_time_reference=false model/framesnet=learnedpd # SO(1,3)
 
 # Input-level symmetry breaking
 python run.py -cp config -cn jctagging model/framesnet=learnedpd data.beam_reference=all # non-equivariant
 python run.py -cp config -cn jctagging model/framesnet=learnedpd # SO(2)
-python run.py -cp config -cn jctagging model/framesnet=learnedpd data.tagging_features_framesnet=zinvariant data.add_time_reference=false # SO(1,1)xSO(2)
-python run.py -cp config -cn jctagging model/framesnet=learnedpd data.tagging_features_framesnet=so3invariant data.beam_reference=null # SO(3)
+python run.py -cp config -cn jctagging model/framesnet=learnedpd data.tagging_features=zinvariant data.add_time_reference=false # SO(1,1)xSO(2)
+python run.py -cp config -cn jctagging model/framesnet=learnedpd data.tagging_features=so3invariant data.beam_reference=null # SO(3)
 # SO(1,3) is the same as for 'architecture'
 ```
 

--- a/experiments/tagging/dataset.py
+++ b/experiments/tagging/dataset.py
@@ -71,7 +71,7 @@ class TopTaggingDataset(TaggingDataset):
         self.data_list = []
         for i in range(kinematics.shape[0]):
             # drop zero-padded components
-            mask = (kinematics[i, ...].abs() > EPS).all(dim=-1)
+            mask = (kinematics[i, ...].abs() > EPS).any(dim=-1)
             fourmomenta = kinematics[i, ...][mask]
             label = labels[i, ...]
             scalars = torch.zeros(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ hydra-core
 pytest
 pre-commit>=3.7
 mlflow-skinny # can optionally install extras, see https://pypi.org/project/mlflow-skinny/
+wget
 
 # standard science stack
 numpy>=1.19.5,<2.0.0 # constrain version for weaver

--- a/tests/experiments/test_tag_invariance.py
+++ b/tests/experiments/test_tag_invariance.py
@@ -13,7 +13,7 @@ from experiments.tagging.experiment import TopTaggingExperiment
 BREAKING = [
     "data.beam_reference=null",
     "data.add_time_reference=false",
-    "data.tagging_features_framesnet=null",
+    "data.tagging_features=null",
 ]
 
 


### PR DESCRIPTION
dense to sparse jet uses .any and thus keeps soft particles 
this dropped 11 real particles across 11 jets on top tagging mini, since any 4 vector with a component less than EPS was dropped, rather than requiring all to be less than EPS to be dropped.
Unless I'm missing something and this was intentional this should be better plus it matches `dense_to_sparse_jet`