### PR TITLE
Several fixes, fully connected graph construction CGENN, MIParT guarding, and pytest removal

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,5 +28,4 @@ jobs:
 
     - name: Run unit tests
       run: |
-        pytest tests/experiments/test_tag_invariance.py
         pytest tests/eventgen

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,5 +28,9 @@ jobs:
 
     - name: Run unit tests
       run: |
-        pytest tests/lloca
+        # tests/lloca does not exist in this repo (the lloca library tests live in the
+        # lloca repo), so this step errored on its first line and tests/experiments was
+        # run by no CI job at all. Run the tagging invariance suite instead; test_tag_flops
+        # stays out of CI because its learned-frame cases need a CUDA-matched xformers build.
+        pytest tests/experiments/test_tag_invariance.py
         pytest tests/eventgen

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,9 +28,5 @@ jobs:
 
     - name: Run unit tests
       run: |
-        # tests/lloca does not exist in this repo (the lloca library tests live in the
-        # lloca repo), so this step errored on its first line and tests/experiments was
-        # run by no CI job at all. Run the tagging invariance suite instead; test_tag_flops
-        # stays out of CI because its learned-frame cases need a CUDA-matched xformers build.
         pytest tests/experiments/test_tag_invariance.py
         pytest tests/eventgen

--- a/experiments/baselines/mipart.py
+++ b/experiments/baselines/mipart.py
@@ -226,10 +226,6 @@ def to_ptrapphim(x, return_mass=True, eps=1e-8, for_onnx=False):
     # x: (N, 4, ...), dim1 : (px, py, pz, E)
     px, py, pz, energy = x.split((1, 1, 1, 1), dim=1)
     pt = torch.sqrt(to_pt2(x, eps=eps))
-    # rapidity = 0.5 * torch.log((energy + pz) / (energy - pz))
-    # clamp BOTH the denominator and the log argument (as in lloca's to_ptrapphim):
-    # for a massless particle exactly along -z the argument (E+pz)/(E-pz) reaches 0
-    # and the log returns -inf. Inactive for any massive particle (mass_reg > 0).
     rapidity = 0.5 * torch.log((1 + (2 * pz) / (energy - pz).clamp(min=1e-20)).clamp(min=1e-20))
     phi = (atan2 if for_onnx else torch.atan2)(py, px)
     if not return_mass:

--- a/experiments/baselines/mipart.py
+++ b/experiments/baselines/mipart.py
@@ -227,7 +227,10 @@ def to_ptrapphim(x, return_mass=True, eps=1e-8, for_onnx=False):
     px, py, pz, energy = x.split((1, 1, 1, 1), dim=1)
     pt = torch.sqrt(to_pt2(x, eps=eps))
     # rapidity = 0.5 * torch.log((energy + pz) / (energy - pz))
-    rapidity = 0.5 * torch.log(1 + (2 * pz) / (energy - pz).clamp(min=1e-20))
+    # clamp BOTH the denominator and the log argument (as in lloca's to_ptrapphim):
+    # for a massless particle exactly along -z the argument (E+pz)/(E-pz) reaches 0
+    # and the log returns -inf. Inactive for any massive particle (mass_reg > 0).
+    rapidity = 0.5 * torch.log((1 + (2 * pz) / (energy - pz).clamp(min=1e-20)).clamp(min=1e-20))
     phi = (atan2 if for_onnx else torch.atan2)(py, px)
     if not return_mass:
         return torch.cat((pt, rapidity, phi), dim=1)

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -41,7 +41,7 @@ class TaggingExperiment(BaseExperiment):
                 self.cfg.model.net.in_s_channels = 0 if self.cfg.model.mean_aggregation else 1
                 self.cfg.model.net.in_s_channels += in_s_channels
             elif modelname == "LorentzNet":
-                self.cfg.model.net.in_s_channels = in_s_channels
+                self.cfg.model.net.n_scalar = in_s_channels
             elif modelname == "PELICAN":
                 self.cfg.model.net.in_channels_rank1 = in_s_channels
             elif modelname == "PELICANOfficial":

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -240,17 +240,19 @@ class TaggingExperiment(BaseExperiment):
             labels_predict.append(y_pred.cpu().float())
         labels_true, labels_predict = torch.cat(labels_true), torch.cat(labels_predict)
 
-        if mode == "eval":
-            metrics["labels_true"], metrics["labels_predict"] = (
-                labels_true,
-                labels_predict,
-            )
-
-        # bce loss
+        # bce loss (from the raw logits)
         metrics["loss"] = torch.nn.functional.binary_cross_entropy_with_logits(
             labels_predict, labels_true
         ).item()
         labels_predict = torch.nn.functional.sigmoid(labels_predict)
+        if mode == "eval":
+            # store the sigmoid PROBABILITIES, not the logits: plot_score histograms
+            # metrics["labels_predict"] over [0, 1] (matplotlib silently drops
+            # out-of-range values, so storing logits made score.pdf meaningless)
+            metrics["labels_true"], metrics["labels_predict"] = (
+                labels_true,
+                labels_predict,
+            )
         labels_true, labels_predict = labels_true.numpy(), labels_predict.numpy()
 
         # accuracy

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -246,9 +246,6 @@ class TaggingExperiment(BaseExperiment):
         ).item()
         labels_predict = torch.nn.functional.sigmoid(labels_predict)
         if mode == "eval":
-            # store the sigmoid PROBABILITIES, not the logits: plot_score histograms
-            # metrics["labels_predict"] over [0, 1] (matplotlib silently drops
-            # out-of-range values, so storing logits made score.pdf meaningless)
             metrics["labels_true"], metrics["labels_predict"] = (
                 labels_true,
                 labels_predict,

--- a/experiments/tagging/wrappers.py
+++ b/experiments/tagging/wrappers.py
@@ -709,13 +709,6 @@ class CGENNWrapper(nn.Module):
         fourmomenta, mask = to_dense_batch(fourmomenta, batch)
         scalars, _ = to_dense_batch(scalars, batch)
         batch_size, n_nodes, _ = fourmomenta.shape
-        # Build the fully-connected (no self-loop) edges among the REAL nodes of each jet
-        # in the DENSE b*n_nodes+i frame that the flattened tensors below actually use.
-        # The previous get_edge_index_from_ptr(ptr, ...) call produced edges in the SPARSE
-        # ptr[b]+i frame; the two frames only agree when every jet in the batch has the
-        # same length, so with variable jet sizes ~1/3 of the edges crossed jet boundaries
-        # or pointed at padded slots, silently scrambling the CGENN message passing and
-        # leaking information across batch-mates.
         pair = mask[:, :, None] & mask[:, None, :]
         pair &= ~torch.eye(n_nodes, dtype=torch.bool, device=mask.device)[None]
         b_idx, i_idx, j_idx = pair.nonzero(as_tuple=True)

--- a/experiments/tagging/wrappers.py
+++ b/experiments/tagging/wrappers.py
@@ -697,9 +697,7 @@ class CGENNWrapper(nn.Module):
         fourmomenta = embedding["fourmomenta"]
         scalars = torch.cat([embedding["scalars"], embedding["tagging_features"]], dim=-1)
         batch = embedding["batch"]
-        ptr = embedding["ptr"]
         is_spurion = embedding["is_spurion"]
-        edge_index = get_edge_index_from_ptr(ptr, fourmomenta.shape, remove_self_loops=True)
 
         # rescale fourmomenta (but not the spurions)
         fourmomenta[~is_spurion] = fourmomenta[~is_spurion] / 20
@@ -711,6 +709,17 @@ class CGENNWrapper(nn.Module):
         fourmomenta, mask = to_dense_batch(fourmomenta, batch)
         scalars, _ = to_dense_batch(scalars, batch)
         batch_size, n_nodes, _ = fourmomenta.shape
+        # Build the fully-connected (no self-loop) edges among the REAL nodes of each jet
+        # in the DENSE b*n_nodes+i frame that the flattened tensors below actually use.
+        # The previous get_edge_index_from_ptr(ptr, ...) call produced edges in the SPARSE
+        # ptr[b]+i frame; the two frames only agree when every jet in the batch has the
+        # same length, so with variable jet sizes ~1/3 of the edges crossed jet boundaries
+        # or pointed at padded slots, silently scrambling the CGENN message passing and
+        # leaking information across batch-mates.
+        pair = mask[:, :, None] & mask[:, None, :]
+        pair &= ~torch.eye(n_nodes, dtype=torch.bool, device=mask.device)[None]
+        b_idx, i_idx, j_idx = pair.nonzero(as_tuple=True)
+        edge_index = torch.stack([b_idx * n_nodes + i_idx, b_idx * n_nodes + j_idx])
         fourmomenta = fourmomenta.view(batch_size * n_nodes, -1)
         scalars = scalars.view(batch_size * n_nodes, -1)
         mask = mask.view(batch_size * n_nodes, -1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ scikit-learn
 
 # deep learning
 torch>=2.0.0
-torch-geometric>=2.6.0 # ptr-only Aggregation calls (tagging/wrappers.py) raise NotImplementedError on <= 2.5
+torch-geometric>=2.6.0
 torch-ema
 pytorch_optimizer>=3.2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ scikit-learn
 
 # deep learning
 torch>=2.0.0
-torch-geometric>=2.4.0
+torch-geometric>=2.6.0 # ptr-only Aggregation calls (tagging/wrappers.py) raise NotImplementedError on <= 2.5
 torch-ema
 pytorch_optimizer>=3.2.0
 


### PR DESCRIPTION
tests/lloca not in repo, only in library repo
mipart rapidity clamp now matches to_ptrapphim
lorentznet has  `n_scalar` not `in_s_channels`
raw logits were previously plotted in range `[0,1]` so histograms only showed that sliver of logits rather than showing sigmoid probabilities, now fixed