### PR TITLE
Change default tag from 'tag_lgatr' to 'top_lgatr' in `jc_lgatr.yaml`

### DIFF
--- a/config/training/jc_lgatr.yaml
+++ b/config/training/jc_lgatr.yaml
@@ -5,4 +5,4 @@ validate_every_n_steps: 10000000
 batchsize: 512
 
 defaults:
- - tag_lgatr
+ - top_lgatr


### PR DESCRIPTION
tag_lgatr is the construction yaml for all tagging not training, that's top_lgatr

whoops!

small oversight but good now, and fix before made it no less broken than it was